### PR TITLE
Add exported module to the package definition

### DIFF
--- a/dict.ipkg
+++ b/dict.ipkg
@@ -1,3 +1,4 @@
 package    "dict"
 pkgs       = contrib
 sourcedir  = src
+modules    = Data.Dict.RedBlackTree


### PR DESCRIPTION
According to https://www.idris-lang.org/documentation/packages/ , the modules must be listed in the package file. As of Idris 1.1.1, `idris --build dict.ipkg` will not produce `RedBlackTree.ibc` unless the module is listed.